### PR TITLE
fix(ui): レスポンシブ状態保持とツールチップ改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
     Map<number, PopulationResponse>
   >(new Map())
   const [prefectures, setPrefectures] = useState<Prefecture[]>([])
-  const isMobile = useResponsive(768)
+  const isMobile = useResponsive(700)
 
   const handlePrefecturesChange = useCallback(
     (newPrefectures: Prefecture[]) => {
@@ -53,54 +53,47 @@ function App() {
 
       <div
         style={{
-          display: isMobile ? 'flex' : 'grid',
-          flexDirection: isMobile ? 'column' : undefined,
-          gridTemplateColumns: isMobile ? undefined : '1fr 2fr',
+          display: 'flex',
+          flexDirection: 'column',
           gap: '20px',
           marginTop: '20px',
+          // デスクトップではgridレイアウトに切り替え
+          ...(isMobile ? {} : {
+            display: 'grid',
+            gridTemplateColumns: '1fr 2fr',
+            flexDirection: undefined,
+          }),
         }}
       >
-        {isMobile ? (
-          // モバイル: グラフを上、都道府県選択を下に
-          <>
-            <section aria-labelledby="chart-title">
-              <PopulationChart
-                data={populationData}
-                selectedPrefs={selectedPrefs}
-                prefectures={prefectures}
-                isMobile={isMobile}
-              />
-            </section>
-            <section aria-labelledby="prefecture-title">
-              <PrefectureList
-                onPrefecturesChange={handlePrefecturesChange}
-                onSelectionChange={handleSelectionChange}
-                onDataChange={handleDataChange}
-                isMobile={isMobile}
-              />
-            </section>
-          </>
-        ) : (
-          // デスクトップ: 都道府県選択を左、グラフを右に
-          <>
-            <section aria-labelledby="prefecture-title">
-              <PrefectureList
-                onPrefecturesChange={handlePrefecturesChange}
-                onSelectionChange={handleSelectionChange}
-                onDataChange={handleDataChange}
-                isMobile={isMobile}
-              />
-            </section>
-            <section aria-labelledby="chart-title">
-              <PopulationChart
-                data={populationData}
-                selectedPrefs={selectedPrefs}
-                prefectures={prefectures}
-                isMobile={isMobile}
-              />
-            </section>
-          </>
-        )}
+        {/* 都道府県選択: モバイル時は2番目、デスクトップ時は1番目 */}
+        <section 
+          aria-labelledby="prefecture-title"
+          style={{
+            order: isMobile ? 2 : 1,
+          }}
+        >
+          <PrefectureList
+            onPrefecturesChange={handlePrefecturesChange}
+            onSelectionChange={handleSelectionChange}
+            onDataChange={handleDataChange}
+            isMobile={isMobile}
+          />
+        </section>
+        
+        {/* グラフ: モバイル時は1番目、デスクトップ時は2番目 */}
+        <section 
+          aria-labelledby="chart-title"
+          style={{
+            order: isMobile ? 1 : 2,
+          }}
+        >
+          <PopulationChart
+            data={populationData}
+            selectedPrefs={selectedPrefs}
+            prefectures={prefectures}
+            isMobile={isMobile}
+          />
+        </section>
       </div>
     </main>
   )

--- a/src/components/PopulationChart.tsx
+++ b/src/components/PopulationChart.tsx
@@ -34,7 +34,19 @@ const COLORS = [
 ]
 
 // カスタムツールチップコンポーネント
-function CustomTooltip({ active, payload, label }: any) {
+type TooltipPayload = {
+  dataKey: string
+  value: number
+  color: string
+}
+
+type CustomTooltipProps = {
+  active?: boolean
+  payload?: TooltipPayload[]
+  label?: string
+}
+
+function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
   if (active && payload && payload.length) {
     return (
       <div
@@ -50,7 +62,7 @@ function CustomTooltip({ active, payload, label }: any) {
         <div style={{ fontWeight: 'bold', marginBottom: '4px', color: '#333' }}>
           {label}年
         </div>
-        {payload.map((entry: any, index: number) => (
+        {payload.map((entry: TooltipPayload, index: number) => (
           <div key={index} style={{ color: entry.color, margin: 0 }}>
             {entry.dataKey}: {entry.value?.toLocaleString()}人
           </div>

--- a/src/components/PopulationChart.tsx
+++ b/src/components/PopulationChart.tsx
@@ -33,6 +33,34 @@ const COLORS = [
   '#f0e68c',
 ]
 
+// カスタムツールチップコンポーネント
+function CustomTooltip({ active, payload, label }: any) {
+  if (active && payload && payload.length) {
+    return (
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '8px 12px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+        }}
+      >
+        {/* 年を上部に表示 */}
+        <div style={{ fontWeight: 'bold', marginBottom: '4px', color: '#333' }}>
+          {label}年
+        </div>
+        {payload.map((entry: any, index: number) => (
+          <div key={index} style={{ color: entry.color, margin: 0 }}>
+            {entry.dataKey}: {entry.value?.toLocaleString()}人
+          </div>
+        ))}
+      </div>
+    )
+  }
+  return null
+}
+
 export default function PopulationChart({
   data,
   selectedPrefs,
@@ -204,7 +232,7 @@ export default function PopulationChart({
               typeof value === 'number' ? value.toLocaleString() : value
             }
           />
-          <Tooltip />
+          <Tooltip content={<CustomTooltip />} />
           <Legend />
           {selectedPrefNames.map((prefName, index) => (
             <Line


### PR DESCRIPTION
  ## 概要

  - レスポンシブデザイン切り替え時のチェックボックス状態保持を修正
  - グラフツールチップのUX向上（年表示追加、数値コンマ区切り）

  ## 変更内容

  ### レスポンシブ状態保持の修正
  - ブレークポイントを768pxから700pxに変更
  - JSX構造の条件分岐を廃止、CSS orderプロパティで制御に変更
  - コンポーネント再マウントを防ぎ、チェックボックス選択状態を維持

  ### ツールチップ改善
  - カスタムツールチップコンポーネントを実装
  - 年ラベルを上部に表示（例: 2005年）
  - 数値にコンマ区切りと単位を追加（例: 5,679,439人）
  - 上部余白の有効活用で情報密度を向上

  ## テスト計画

  - [x] ブラウザ幅700px前後での切り替えテスト
  - [x] チェックボックス状態保持の確認
  - [x] ツールチップ表示の確認
  - [x] ビルド・リント通過確認
  - [x] レスポンシブデザインの動作確認